### PR TITLE
Fix Insecure Content Warning

### DIFF
--- a/common/header.php
+++ b/common/header.php
@@ -24,7 +24,7 @@
     <!-- Stylesheets -->
     <?php
     queue_css_file('style');
-    queue_css_url('http://fonts.googleapis.com/css?family=PT+Serif:400,700,400italic,700italic');
+    queue_css_url('//fonts.googleapis.com/css?family=PT+Serif:400,700,400italic,700italic');
     echo head_css();
 
     echo theme_header_background();


### PR DESCRIPTION
Removed the http:// from the non https:// links and changed to the agnostic // style. Where it will pick the transport layer that is being used for browsing.

If browsing http:// it will assume http://. If browsing https:// it will assume https://
